### PR TITLE
Fix left offset when scrolling to search result

### DIFF
--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -193,8 +193,14 @@ class TextHighlighter {
         span.className = `${className} appended`;
         span.append(node);
         div.append(span);
-        return className.includes("selected") ? span.offsetLeft : 0;
+        if (className.includes("selected")) {
+          const { left } = span.getClientRects()[0];
+          const parentLeft = div.getBoundingClientRect().left;
+          return left - parentLeft;
+        }
+        return 0;
       }
+
       div.append(node);
       return 0;
     }


### PR DESCRIPTION
Fixes https://github.com/mozilla/pdf.js/issues/19207. While approaches based on improving the font match in the text layer so that we don't need to scale help, they are not a complete solution because in some cases CSS scaling cannot be removed (such as in https://github.com/mozilla/pdf.js/pull/18283).