### PR TITLE
Fix autolinking errors

### DIFF
--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -77,6 +77,8 @@ class AnnotationLayerBuilder {
 
   #eventAbortController = null;
 
+  #linksInjected = false;
+
   /**
    * @param {AnnotationLayerBuilderOptions} options
    */
@@ -235,9 +237,10 @@ class AnnotationLayerBuilder {
         "`render` method must be called before `injectLinkAnnotations`."
       );
     }
-    if (this._cancelled) {
+    if (this._cancelled || this.#linksInjected) {
       return;
     }
+    this.#linksInjected = true;
 
     const newLinks = this.#annotations.length
       ? this.#checkInferredLinks(inferredLinks)


### PR DESCRIPTION
This commit fixes some edge cases in the autolinking logic and adds tests for them. It fixes the issues with regexp, email validation as well as link annotations being injected multiple times on zoom.

Fixes: https://github.com/mozilla/pdf.js/issues/19462