### PR TITLE
Ignore empty paths when optimizing constructPath operations (issue 19971)

### DIFF
--- a/src/core/operator_list.js
+++ b/src/core/operator_list.js
@@ -519,18 +519,20 @@ addState(
     const transform = argsArray[iFirstTransform];
     const [, [buffer], minMax] = args;
 
-    Util.scaleMinMax(transform, minMax);
-    for (let k = 0, kk = buffer.length; k < kk; ) {
-      switch (buffer[k++]) {
-        case DrawOPS.moveTo:
-        case DrawOPS.lineTo:
-          Util.applyTransform(buffer, transform, k);
-          k += 2;
-          break;
-        case DrawOPS.curveTo:
-          Util.applyTransformToBezier(buffer, transform, k);
-          k += 6;
-          break;
+    if (minMax) {
+      Util.scaleMinMax(transform, minMax);
+      for (let k = 0, kk = buffer.length; k < kk; ) {
+        switch (buffer[k++]) {
+          case DrawOPS.moveTo:
+          case DrawOPS.lineTo:
+            Util.applyTransform(buffer, transform, k);
+            k += 2;
+            break;
+          case DrawOPS.curveTo:
+            Util.applyTransformToBezier(buffer, transform, k);
+            k += 6;
+            break;
+        }
       }
     }
     // Replace queue items.


### PR DESCRIPTION
Note how we're handling empty paths in [src/display/canvas.js](https://github.com/mozilla/pdf.js/blob/a8e05d82e23056ddc2c28f83854b6f74ffa4bebc/src/display/canvas.js#L1423-L1428), hence we need add similar code in the QueueOptimizer as well.